### PR TITLE
Fix for php 7.1 converting string to array

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -484,10 +484,10 @@ function splitQueryText($query) {
 	// i spent 3 days figuring out this line
 	preg_match_all("/(?>[^;']|(''|(?>'([^']|\\')*[^\\\]')))+;/ixU", $query, $matches, PREG_SET_ORDER);
 
-	$querySplit = "";
+	$querySplit = array();
 
 	foreach ($matches as $match) {
-		// get rid of the trailing semicolon
+		// get rid of the trailing semicolon		
 		$querySplit[] = substr($match[0], 0, -1);
 	}
 


### PR DESCRIPTION
The variable $queryString was silently converted to an array pre  php 7.1 